### PR TITLE
Fixed issues

### DIFF
--- a/Nozzle-Clean/Patterns/pattern0.cfg
+++ b/Nozzle-Clean/Patterns/pattern0.cfg
@@ -68,6 +68,6 @@ gcode:
       G1 X{cx} Y{pad_y + pad_d} F{wipe_f}
       G1 X{cx} Y{pad_y}         F{wipe_f}
     {% else %}
-      {action_raise_error("_WIPE_PATTERN_1_CLEAN: WIPE_AXIS must be X or Y")}
+      {action_raise_error("_WIPE_PATTERN_CLEAN_0: WIPE_AXIS must be X or Y")}
     {% endif %}
   {% endfor %}

--- a/Nozzle-Clean/Patterns/pattern1.cfg
+++ b/Nozzle-Clean/Patterns/pattern1.cfg
@@ -22,14 +22,8 @@ gcode:
   {% set pad_d      = params.PAD_D|float %}
   {% set travelxy_f = params.TRAVELXY_F|float %}
 
-  # Move into the start position which is the pad's front corner
-  {% if wipe_axis == "X" %}
-    G1 X{pad_x} Y{pad_y} F{travelxy_f}
-  {% elif wipe_axis == "Y" %}
-    G1 X{pad_x} Y{pad_y} F{travelxy_f}
-  {% else %}
-    {action_raise_error("_WIPE_PATTERN_START_1: WIPE_AXIS must be X or Y")}
-  {% endif %}
+  # Pattern 1 always starts at the minimum corner regardless of wipe axis.
+  G1 X{pad_x} Y{pad_y} F{travelxy_f}
 
 [gcode_macro _WIPE_PATTERN_CLEAN_1]
 description: Wipe the nozzle across the full length of the pad in a zig-zag pattern
@@ -94,8 +88,8 @@ gcode:
         # right side of the pad advancing Y.
         G1 X{cx1} Y{pad_y + pad_d} F{wipe_f}
 
-        # Make the second diagonal movement back to
-        # the left side of the pad advancing Y.
+        # Make the second diagonal movement to
+        # the near/front edge of the pad.
         G1 X{cx2} Y{pad_y} F{wipe_f}
       {% elif wipe_axis == "Y" %}
         # Wiping in Y direction
@@ -123,8 +117,8 @@ gcode:
           {% set cy2 = (pad_y + pad_d) %}
         {% endif %}
 
-        # Make the first diagonal movement to the
-        # right side of the pad advancing Y.
+        # Make the first diagonal movement to
+        # the far/back edge of the pad.
         G1 X{pad_x + pad_w} Y{cy1} F{wipe_f}
 
         # Make the second diagonal movement back to

--- a/Nozzle-Clean/Patterns/pattern3.cfg
+++ b/Nozzle-Clean/Patterns/pattern3.cfg
@@ -58,7 +58,7 @@ gcode:
   # Get the configuration parameters
   {% set cfg = printer["gcode_macro _WIPE_PATTERN_PARAMETERS_3"] %}
 
-  # Validate loop count before using it as a divisor
+  # Validate loop count before using it as a divisor (must be >= 1)
   {% if cfg.loop_count < 1 %}
     {action_raise_error("_WIPE_PATTERN_CLEAN_3: loop_count must be >= 1")}
   {% endif %}

--- a/Nozzle-Clean/Patterns/pattern3.cfg
+++ b/Nozzle-Clean/Patterns/pattern3.cfg
@@ -58,6 +58,11 @@ gcode:
   # Get the configuration parameters
   {% set cfg = printer["gcode_macro _WIPE_PATTERN_PARAMETERS_3"] %}
 
+  # Validate loop count before using it as a divisor
+  {% if cfg.loop_count < 1 %}
+    {action_raise_error("_WIPE_PATTERN_CLEAN_3: loop_count must be >= 1")}
+  {% endif %}
+
   # Compute the center of the pad
   {% set cx = pad_x + (pad_w / 2.0) %}
   {% set cy = pad_y + (pad_d / 2.0) %}

--- a/Nozzle-Clean/nozzle-clean.cfg
+++ b/Nozzle-Clean/nozzle-clean.cfg
@@ -43,11 +43,11 @@ description: Clean the nozzle using a cleaning pad.
 # Optional parameters:
 #   TEMP:             Nozzle cleaning temperature
 #   PASSES:           Number of wipe passes
-#   PATTERN:          Set the pattern (0 = straight, 1 = zig-zag pattern)
+#   PATTERN:          Set the pattern (0 = straight, 1 = zig-zag, 2 = wave, 3 = spiral inward)
 #   Z:                Override wipe Z height for this run
 #   KEEP_HOTEND_ON:   Set to 1 to keep hotend on, 0 to turn hotend off when complete
 #   RETRACT_DISTANCE: Override the default retract distance
-#   RETRACT_F:        Override the default retract distance
+#   RETRACT_F:        Override the default retract feed rate
 gcode:
   # Get configuration parameters
   {% set cfg = printer["gcode_macro _NOZZLE_PARAMETERS"] %}

--- a/Nozzle-Clean/nozzle-clean.md
+++ b/Nozzle-Clean/nozzle-clean.md
@@ -158,7 +158,7 @@ Edit these values to match the position and size of your cleaning pad.
 
 > **Wipe Z is calculated automatically** from the pad geometry:
 > - If `nozzle_height > brush_height`: `wipe_z = base_height + z` (nozzle fully enters the brush)
-> - Otherwise: `wipe_z = base_height + brush_height - nozzle_height + z` (nozzle contacts brush top)
+> - Otherwise: `wipe_z = base_height + brush_height - nozzle_height + z` (nozzle tip is submerged by the full `nozzle_height` into the brush)
 >
 > Use `NOZZLE_PAD_Z` to display the calculated value before wiping.
 
@@ -266,7 +266,7 @@ Traces the pad perimeter (optionally inset) to validate pad geometry and positio
 |---|---:|---:|---|
 | `PASSES` | int | `default_passes` | Number of perimeter loops |
 | `INSET` | float | `0.0` | Inset from pad edges (mm) |
-| `Z` | float | `base_height + brush_height + 3` | Z height to trace at (absolute) |
+| `Z` | float | `base_height + brush_height + z + 3` | Z height to trace at (absolute) |
 
 #### Usage
 Trace exact pad perimeter:
@@ -336,7 +336,7 @@ For **Pattern 1 (Zig-Zag)**:
 - The nozzle starts at the pad's minimum corner and sweeps diagonally across the pad surface in 10 steps per pass, reversing direction each pass to cover the full pad area.
 
 For **Pattern 3 (Spiral Inward)**:
-- The nozzle starts at the front-left corner of the pad and traces a series of concentric rectangles, stepping inward by an equal amount on every loop. After `variable_loop_count` loops the center of the pad is reached, then the nozzle moves to the center to finish the pass. The number of concentric rectangles per pass is set by `variable_loop_count` in `_WIPE_PATTERN_PARAMETERS_3` (`Patterns/pattern3.cfg`).
+- The nozzle traces `variable_loop_count` concentric rectangles spiraling inward, stopping one step short of center. After all loops complete, the nozzle moves to the center of the pad to finish the pass.
 - This pattern covers the entire pad surface regardless of which axis is longer.
 
 ---

--- a/Nozzle-Clean/nozzle-clean.md
+++ b/Nozzle-Clean/nozzle-clean.md
@@ -336,7 +336,7 @@ For **Pattern 1 (Zig-Zag)**:
 - The nozzle starts at the pad's minimum corner and sweeps diagonally across the pad surface in 10 steps per pass, reversing direction each pass to cover the full pad area.
 
 For **Pattern 3 (Spiral Inward)**:
-- The nozzle traces `variable_loop_count` concentric rectangles spiraling inward, stopping one step short of center. After all loops complete, the nozzle moves to the center of the pad to finish the pass.
+- The nozzle traces `variable_loop_count` concentric rectangles spiraling inward, stopping one step short of center. After all loops complete, the nozzle moves to the center of the pad to finish the pass. This pattern is repeated for each pass.
 - This pattern covers the entire pad surface regardless of which axis is longer.
 
 ---

--- a/Nozzle-Clean/parameters.cfg
+++ b/Nozzle-Clean/parameters.cfg
@@ -18,7 +18,7 @@ variable_wipe_f:                   4000  # Wipe feedrate (mm/min)
 # Default values for macro parameters
 variable_default_temp:              200  # Default cleaning temp if TEMP not provided
 variable_default_passes:              5  # The default number of times to wipe the nozzle
-variable_default_keep_hotend_on:      1  # Keep the hotend heated since this command is macro will be used during a print.
+variable_default_keep_hotend_on:      1  # Keep the hotend heated since this macro may be used during a print.
 variable_default_retract_distance:   -1  # The distance the filament will be retracted before cleaning
 variable_default_retract_f:        1800  # Retraction feedrate (mm/min)
 variable_default_wipe_pattern:        0  # See pattern files for possible values


### PR DESCRIPTION
This pull request makes several improvements and clarifications to the nozzle cleaning macros, including documentation updates, error handling enhancements, and minor code corrections. The changes help ensure more robust macro behavior, clearer documentation, and better parameter validation.

**Documentation improvements:**

* Updated the description of the `PATTERN` parameter to include all four available patterns and clarified the meaning of the `RETRACT_F` parameter in `nozzle-clean.cfg`.
* Improved explanations in the documentation (`nozzle-clean.md`) for wipe Z height calculation, perimeter tracing Z formula, and the behavior of Pattern 3 (spiral inward). [[1]](diffhunk://#diff-4832cd82606b22dfabada81f7ce4ede61534e3f3f4de57e1193ca0b7d3a3bff6L161-R161) [[2]](diffhunk://#diff-4832cd82606b22dfabada81f7ce4ede61534e3f3f4de57e1193ca0b7d3a3bff6L269-R269) [[3]](diffhunk://#diff-4832cd82606b22dfabada81f7ce4ede61534e3f3f4de57e1193ca0b7d3a3bff6L339-R339)
* Fixed a comment typo in `parameters.cfg` for `variable_default_keep_hotend_on`.

**Macro logic and error handling:**

* Added validation in `pattern3.cfg` to ensure `loop_count` is at least 1, raising an error if not.
* Updated error messages in `pattern0.cfg` and `pattern1.cfg` for consistency and clarity regarding invalid `WIPE_AXIS` values. [[1]](diffhunk://#diff-caa3c70c3101a30543d491740e17411376b63c2da90077e334eb17e30359dfd9L71-R71) [[2]](diffhunk://#diff-d5e0775e4c6d2bf62c536b55202dad2794b3557d9c5bd019b16150ff55900ff9L25-L32)

**Pattern behavior and comments:**

* Clarified movement comments in `pattern1.cfg` to better describe diagonal wipe motions for both X and Y axes. [[1]](diffhunk://#diff-d5e0775e4c6d2bf62c536b55202dad2794b3557d9c5bd019b16150ff55900ff9L97-R92) [[2]](diffhunk://#diff-d5e0775e4c6d2bf62c536b55202dad2794b3557d9c5bd019b16150ff55900ff9L126-R121)
* Simplified the starting position logic for Pattern 1 to always use the minimum pad corner, regardless of axis.